### PR TITLE
Rollback + Fix: Restauración al commit 4feb3968 + ajustes en liquidaciones

### DIFF
--- a/src/facturacion-electronica/controllers/liquidacion-compra.controller.ts
+++ b/src/facturacion-electronica/controllers/liquidacion-compra.controller.ts
@@ -162,23 +162,6 @@ export class LiquidacionCompraController {
   @ApiResponse({
     status: 200,
     description: 'Archivo Excel generado correctamente',
-    headers: {
-      'Content-Type': {
-        description: 'Tipo de contenido del archivo',
-        schema: {
-          type: 'string',
-          example:
-            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-        },
-      },
-      'Content-Disposition': {
-        description: 'Disposición del contenido como archivo adjunto',
-        schema: {
-          type: 'string',
-          example: 'attachment; filename=liquidaciones-compra.xlsx',
-        },
-      },
-    },
   })
   async descargarExcelLiquidaciones(@Res() response: Response) {
     try {
@@ -208,6 +191,45 @@ export class LiquidacionCompraController {
       )
       throw new Error(
         'Error al generar Excel de liquidaciones: ' + error.message,
+      )
+    }
+  }
+
+  @Get('descargar-excel-no-anulados')
+  @ApiOperation({
+    summary: 'Descargar Excel con liquidaciones NO ANULADAS',
+    description:
+      'Genera y descarga un archivo Excel solo con las liquidaciones de compra que NO están anuladas',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Archivo Excel generado correctamente',
+  })
+  async descargarExcelLiquidacionesNoAnuladas(@Res() response: Response) {
+    try {
+      this.logger.log(
+        'Generando reporte Excel de liquidaciones NO ANULADAS',
+      )
+      const liquidaciones =
+        await this.service.obtenerLiquidacionesNoAnuladasParaExcel()
+      this.logger.log(
+        `Obtenidas ${liquidaciones.length} liquidaciones NO ANULADAS para Excel`,
+      )
+      await this.excelService.generarReporteLiquidaciones(
+        response,
+        liquidaciones,
+      )
+      this.logger.log(
+        `Excel generado con ${liquidaciones.length} liquidaciones NO ANULADAS`,
+      )
+    } catch (error) {
+      this.logger.error(
+        'Error al generar Excel de liquidaciones no anuladas:',
+        error.message,
+      )
+      throw new Error(
+        'Error al generar Excel de liquidaciones no anuladas: ' +
+          error.message,
       )
     }
   }

--- a/src/facturacion-electronica/services/electronic-liquidacion.service.ts
+++ b/src/facturacion-electronica/services/electronic-liquidacion.service.ts
@@ -651,4 +651,45 @@ export class ElectronicLiquidacionService {
       }
     }
   }
+
+  async obtenerLiquidacionesNoAnuladasParaExcel() {
+    try {
+      this.logger.log(
+        'Iniciando consulta para obtener liquidaciones NO ANULADAS para Excel',
+      )
+
+      const liquidaciones = await this.prisma.liquidacionCompra.findMany({
+        where: {
+          estadoSri: {
+            not: 'ANULADO',
+          },
+        },
+        orderBy: { fechaEmision: 'desc' },
+        select: {
+          id: true,
+          fechaEmision: true,
+          dirEstablecimiento: true,
+          tipoIdentificacionProveedor: true,
+          razonSocialProveedor: true,
+          identificacionProveedor: true,
+          totalSinImpuestos: true,
+          totalDescuento: true,
+          importeTotal: true,
+          moneda: true,
+          estadoSri: true,
+          accessKey: true,
+          createdAt: true,
+        },
+      })
+
+      this.logger.log(
+        `Encontradas ${liquidaciones.length} liquidaciones NO ANULADAS para Excel`,
+      )
+      return liquidaciones
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : 'Error desconocido'
+      this.logger.error('Error al obtener liquidaciones no anuladas para Excel: ' + msg)
+      throw new Error('Error al obtener liquidaciones no anuladas para Excel: ' + msg)
+    }
+  }
 }


### PR DESCRIPTION
This pull request adds functionality to generate and download an Excel report containing only non-annulled purchase liquidations. It introduces a new endpoint in the controller and implements the corresponding service method to fetch the required data. Additionally, it simplifies the API response metadata for Excel downloads.

**New Feature: Download Excel of Non-Annulled Liquidations**
* Controller: Added the `descargar-excel-no-anulados` endpoint to `LiquidacionCompraController`, allowing users to download an Excel file with only non-annulled purchase liquidations.
* Service: Implemented `obtenerLiquidacionesNoAnuladasParaExcel` in `ElectronicLiquidacionService` to query and return non-annulled liquidations for the Excel report.

**API Response Simplification**
* Controller: Removed explicit `Content-Type` and `Content-Disposition` header descriptions from the Excel download API response metadata for cleaner documentation.
[Copilot is generating a summary...]